### PR TITLE
Update XrayR.sh

### DIFF
--- a/XrayR.sh
+++ b/XrayR.sh
@@ -120,7 +120,14 @@ update() {
 }
 
 config() {
-    cat /etc/XrayR/config.yml
+   vi /etc/XrayR/config.yml
+   echo "是否现在重启xrayr？[Y/n]" && echo
+        read -e -p "(默认: y):" yn
+        [[ -z ${yn} ]] && yn="y"
+        if [[ ${yn} == [Yy] ]]; then
+               check_install && restart
+        fi
+
 }
 
 uninstall() {
@@ -370,7 +377,7 @@ show_menu() {
     echo -e "
   ${green}XrayR 后端管理脚本，${plain}${red}不适用于docker${plain}
 --- https://github.com/XrayR-project/XrayR ---
-  ${green}0.${plain} 退出脚本
+  ${green}0.${plain} 修改配置
 ————————————————
   ${green}1.${plain} 安装 XrayR
   ${green}2.${plain} 更新 XrayR
@@ -394,7 +401,7 @@ show_menu() {
     echo && read -p "请输入选择 [0-13]: " num
 
     case "${num}" in
-        0) exit 0
+        0) config
         ;;
         1) check_uninstall && install
         ;;

--- a/XrayR.sh
+++ b/XrayR.sh
@@ -120,14 +120,25 @@ update() {
 }
 
 config() {
-   vi /etc/XrayR/config.yml
-   echo "是否现在重启xrayr？[Y/n]" && echo
-        read -e -p "(默认: y):" yn
-        [[ -z ${yn} ]] && yn="y"
-        if [[ ${yn} == [Yy] ]]; then
-               check_install && restart
-        fi
-
+    echo "XrayR在修改配置后会自动尝试重启"
+    vi /etc/XrayR/config.yml
+    sleep 2
+    check_status
+    case $? in
+        0)
+            echo -e "XrayR状态: ${green}已运行${plain}"
+            ;;
+        1)
+            echo -e "检测到您未启动XrayR或XrayR自动重启失败，是否查看日志？[Y/n]" && echo
+            read -e -p "(默认: y):" yn
+            [[ -z ${yn} ]] && yn="y"
+            if [[ ${yn} == [Yy] ]]; then
+               show_log
+            fi
+            ;;
+        2)
+            echo -e "XrayR状态: ${red}未安装${plain}"
+    esac
 }
 
 uninstall() {


### PR DESCRIPTION
蹩脚的添加了快捷修改配置菜单。将原来的0菜单退出脚本，改为修改配置。（退出直接ctrl+c就好了）。

新菜单如下：
`  XrayR 后端管理脚本，不适用于docker
--- https://github.com/XrayR-project/XrayR ---
  0. 修改配置
————————————————
  1. 安装 XrayR
  2. 更新 XrayR
  3. 卸载 XrayR
————————————————
  4. 启动 XrayR
  5. 停止 XrayR
  6. 重启 XrayR
  7. 查看 XrayR 状态
  8. 查看 XrayR 日志
————————————————
  9. 设置 XrayR 开机自启
 10. 取消 XrayR 开机自启
————————————————
 11. 一键安装 bbr (最新内核)
 12. 查看 XrayR 版本
 13. 升级维护脚本

XrayR状态: 已运行
是否开机自启: 是

请输入选择 [0-13]: 0`

修改完成wq保存后，会提示：

`是否现在重启xrayr？[Y/n]

(默认: y):
XrayR 重启成功，请使用 XrayR log 查看运行日志

按回车返回主菜单:
`