### PR TITLE
arch: support armbian

### DIFF
--- a/XrayR.sh
+++ b/XrayR.sh
@@ -15,6 +15,8 @@ if [[ -f /etc/redhat-release ]]; then
     release="centos"
 elif cat /etc/issue | grep -Eqi "debian"; then
     release="debian"
+elif cat /etc/issue | grep -Eqi "Armbian"; then
+    release="armbian"
 elif cat /etc/issue | grep -Eqi "ubuntu"; then
     release="ubuntu"
 elif cat /etc/issue | grep -Eqi "centos|red hat|redhat"; then
@@ -47,9 +49,9 @@ elif [[ x"${release}" == x"ubuntu" ]]; then
     if [[ ${os_version} -lt 16 ]]; then
         echo -e "${red}请使用 Ubuntu 16 或更高版本的系统！${plain}\n" && exit 1
     fi
-elif [[ x"${release}" == x"debian" ]]; then
+elif [[ x"${release}" == x"debian" || x"${release}" == x"armbian" ]]; then
     if [[ ${os_version} -lt 8 ]]; then
-        echo -e "${red}请使用 Debian 8 或更高版本的系统！${plain}\n" && exit 1
+        echo -e "${red}请使用 Debian//Armbian 8 或更高版本的系统！${plain}\n" && exit 1
     fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,8 @@ if [[ -f /etc/redhat-release ]]; then
     release="centos"
 elif cat /etc/issue | grep -Eqi "debian"; then
     release="debian"
+elif cat /etc/issue | grep -Eqi "Armbian"; then
+    release="armbian"
 elif cat /etc/issue | grep -Eqi "ubuntu"; then
     release="ubuntu"
 elif cat /etc/issue | grep -Eqi "centos|red hat|redhat"; then
@@ -33,6 +35,8 @@ arch=$(arch)
 
 if [[ $arch == "x86_64" || $arch == "x64" || $arch == "amd64" ]]; then
     arch="64"
+elif [[ $arch == "armv7l" ]]; then
+    arch="arm32-v7a"
 elif [[ $arch == "aarch64" || $arch == "arm64" ]]; then
     arch="arm64-v8a"
 elif [[ $arch == "s390x" ]]; then
@@ -67,9 +71,9 @@ elif [[ x"${release}" == x"ubuntu" ]]; then
     if [[ ${os_version} -lt 16 ]]; then
         echo -e "${red}请使用 Ubuntu 16 或更高版本的系统！${plain}\n" && exit 1
     fi
-elif [[ x"${release}" == x"debian" ]]; then
+elif [[ x"${release}" == x"debian" || x"${release}" == x"armbian" ]]; then
     if [[ ${os_version} -lt 8 ]]; then
-        echo -e "${red}请使用 Debian 8 或更高版本的系统！${plain}\n" && exit 1
+        echo -e "${red}请使用 Debian/Armbian 8 或更高版本的系统！${plain}\n" && exit 1
     fi
 fi
 


### PR DESCRIPTION
Add Armbian support.
 Test passed on Onecloud Armbian 24.5.1 Bookworm.